### PR TITLE
Improve output in successful case

### DIFF
--- a/lib/docception.ex
+++ b/lib/docception.ex
@@ -83,6 +83,9 @@ defmodule Docception do
       if Enum.any?(results, &(&1 != :normal)) do
         raise Error, "Failed tests found"
       else
+        message = "#{length(results)} doctests passed"
+        IO.puts(IO.ANSI.format_fragment([:green, to_charlist(message)]))
+
         :ok
       end
     after

--- a/lib/mix/tasks/docception.ex
+++ b/lib/mix/tasks/docception.ex
@@ -17,7 +17,7 @@ defmodule Mix.Tasks.Docception do
     # doctests.
     Mix.Task.run "compile"
 
-    ExUnit.start()
+    ExUnit.start(formatters: [])
 
     verbose? = true
 


### PR DESCRIPTION
This PR makes two changes to improve the output in the successful case (the failure case is unchanged):
1. Print out the number of successful tests
2. Disable the default `ExUnit.CLIFormatter`

Without this change:
```
$ MIX_ENV=test mix docception README.md
Docception: README.md

Finished in 0.05 seconds (0.05s on load, 0.00s on tests)
0 failures
```

With this change:
```
$ MIX_ENV=test mix docception README.md
Docception: README.md
3 doctests passed
```

I think this is an improvement because the ExUnit.CLIFormatter output
was incorrect because we're not actually running any ExUnit tests. And
the timings appear to be incorrect as well (I tested by putting a
`Process.sleep(1_000)` in a test and it was counted as part of the load
time), also I also think that generally tests run in a markdown file
will be fast.

I think the number of passing tests is important to include to more
easily check that all your markdown tests are running.